### PR TITLE
v1.1.1

### DIFF
--- a/lib/video/video_tab.py
+++ b/lib/video/video_tab.py
@@ -597,7 +597,7 @@ class VideoTab(ttk.Frame):
         def worker():
             ok = True
             for idx, src in enumerate(self.files, start=1):
-                dst = Path(out_dir) / f"{src.name}.avi"
+                dst = Path(out_dir) / f"{src.stem}.avi"
                 self.log_q.put(f"[*] Converting {src.name} -> {dst.name}")
 
                 vf = self._vf_convert()

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from lib.common.ffmpeg_tools import resolve_ffmpeg_path
 from lib.common.os_utils import _no_console_kwargs
 
 APP_TITLE = "Pip-Boy 3000 Mk V - Media Conversion Tool"
-APP_VERSION = "1.1.0"
+APP_VERSION = "1.1.1"
 
 FFMPEG_CMD = resolve_ffmpeg_path()
 


### PR DESCRIPTION
## Pip-Boy 3000 Mk V Media Conversion Tool - Pull Request

### Description

Quick patch to file names. Fix file names keeping from their old extensions, bug `xyz.mp4` > `xyz.mp4.avi`. Now properly named as `xyz.avi` on conversion.
